### PR TITLE
One more change to default CA cert path

### DIFF
--- a/src/modules/client/imageconfig.py
+++ b/src/modules/client/imageconfig.py
@@ -74,7 +74,7 @@ CA_PATH = "ca-path"
 default_properties = {
         CA_PATH: os.path.join(os.path.sep, "etc", "ssl", "certs"),
         # Path default is intentionally relative for this case.
-        "trust-anchor-directory": os.path.join("etc", "certs", "CA"),
+        "trust-anchor-directory": os.path.join("etc", "ssl", "certs"),
 }
 
 # Assume the repository metadata should be checked no more than once every


### PR DESCRIPTION
Matching commit to http://omnios.omniti.com/changeset.php/core/pkg/d41e76e005b53653e711efa9b2b79fdd8f38655d which has been tested under r151006.
